### PR TITLE
Upgrade some github actions

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -5,11 +5,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
             toolchain: nightly
             components: clippy
-            override: true
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,10 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: stable
-        override: true
         components: llvm-tools-preview  # Required for grcov
 
     - name: Build

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -36,7 +36,7 @@ jobs:
       with:
         # Repository upload token - get it from codecov.io. Required only for private repositories
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./lcov.info
+        files: ./lcov.info
         # Specify whether the Codecov output should be verbose
         verbose: true
         fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ matrix.config.toolchain }}
-            override: true
 
       # NB see https://github.com/actions-rs/cargo if we ever want to try cross
       # e.g. for Mac M1/arm64
@@ -82,12 +81,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
         with:
             toolchain: stable
-            override: true
-      - uses: katyo/publish-crates@v1
+      - uses: katyo/publish-crates@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
             registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sketchlib"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     "John Lees <jlees@ebi.ac.uk>",
     "Nicholas Croucher <n.croucher@imperial.ac.uk>",


### PR DESCRIPTION
Trying to avoid deprecated actions used in the toolchain install (which is no longer maintained)