### PR TITLE
fix: Removed deprecated cargo_bin() function in snapbox

### DIFF
--- a/tests/completeness.rs
+++ b/tests/completeness.rs
@@ -1,5 +1,5 @@
 use approx::assert_abs_diff_eq;
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 pub mod common;
 use crate::common::TestSetup;
@@ -7,6 +7,7 @@ use crate::common::*;
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     /// Assert function with tolerance for distance comparisons using approx crate
@@ -24,7 +25,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("R6.fa.gz");
 
         // Create sketch database with genomes in alphabetical order
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -57,7 +58,7 @@ mod tests {
         );
 
         // First, let's inspect the sketch database to understand genome ordering
-        let sketch_info_output = Command::new(cargo_bin("sketchlib"))
+        let sketch_info_output = Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("info")
@@ -77,7 +78,7 @@ mod tests {
         println!("{}", completeness_content);
 
         // Calculate distances WITHOUT completeness correction
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test_genomes")
@@ -88,7 +89,7 @@ mod tests {
             .success();
 
         // Calculate distances WITH completeness correction using default cutoff (0.64)
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test_genomes")
@@ -102,7 +103,7 @@ mod tests {
 
         // Calculate distances WITH completeness correction using high cutoff (0.8)
         // This should correct no pairs since all c1*c2 products < 0.8
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test_genomes")
@@ -249,7 +250,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("R6.fa.gz");
 
         // Create sketch database
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -274,7 +275,7 @@ mod tests {
 
         // Calculate distances with missing genome in completeness file
         // This should succeed and use default completeness of 1.0 for R6
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test_missing")
@@ -317,7 +318,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("14412_3#84.contigs_velvet.fa.gz");
 
         // Create sketch database with only 2 genomes
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -343,7 +344,7 @@ mod tests {
 
         // Calculate distances with extra genomes in completeness file
         // This should succeed and ignore the extra genomes
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test_extra")
@@ -387,7 +388,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("R6.fa.gz");
 
         // Create inverted index for preclustering
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("build")
@@ -401,7 +402,7 @@ mod tests {
             .success();
 
         // Create standard sketch database
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -425,7 +426,7 @@ mod tests {
         );
 
         // Run precluster with completeness correction
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("precluster")
@@ -472,7 +473,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("14412_3#84.contigs_velvet.fa.gz");
 
         // Create sketch database
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -496,7 +497,7 @@ mod tests {
         );
 
         // Calculate distances WITHOUT completeness correction
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("formula_test")
@@ -507,7 +508,7 @@ mod tests {
             .success();
 
         // Calculate distances WITH completeness correction
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("formula_test")

--- a/tests/concat.rs
+++ b/tests/concat.rs
@@ -1,5 +1,5 @@
 use predicates::prelude::*;
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 use std::path::Path;
 
 pub mod common;
@@ -16,7 +16,7 @@ mod tests {
     fn test_concat_sketches() {
         let sandbox = TestSetup::setup();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -27,7 +27,7 @@ mod tests {
             .assert()
             .success();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -38,7 +38,7 @@ mod tests {
             .assert()
             .success();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -52,7 +52,7 @@ mod tests {
             .success();
 
         // Overlapping labels fails
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("concat")
             .arg("part1")
@@ -63,7 +63,7 @@ mod tests {
             .assert()
             .failure();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("append")
             .arg("part1")

--- a/tests/delete.rs
+++ b/tests/delete.rs
@@ -1,5 +1,5 @@
 use predicates::prelude::*;
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 use std::path::Path;
 
 pub mod common;
@@ -22,7 +22,7 @@ mod tests {
             "R6.fa.gz",
             "TIGR4.fa.gz",
         ]);
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -36,7 +36,7 @@ mod tests {
             "14412_3#82.contigs_velvet.fa.gz",
             "14412_3#84.contigs_velvet.fa.gz",
         ]);
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -46,7 +46,7 @@ mod tests {
             .assert()
             .success();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("delete")
             .arg("full_db")

--- a/tests/distance.rs
+++ b/tests/distance.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 use std::path::Path;
 
 pub mod common;
@@ -83,7 +83,7 @@ mod tests {
         //Test 1: One short sequence vs one short seqeunce (1 SNP apart)
 
         //Test 1 begin -------------
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "3"])
@@ -95,7 +95,7 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("test1_part1.skd"));
         assert_eq!(true, sandbox.file_exists("test1_part1.skm"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "3"])
@@ -107,7 +107,7 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("test1_part2.skd"));
         assert_eq!(true, sandbox.file_exists("test1_part2.skm"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test1_part1")
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("short_sequence_dist_3"));
 
         //Test 2 begin -------------
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -133,7 +133,7 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("test2_part1.skm"));
 
         // removed second to last contigs which is 3610 bps
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -148,7 +148,7 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("test2_part2.skd"));
         assert_eq!(true, sandbox.file_exists("test2_part2.skm"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test2_part1")
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("test2_rust_results"));
 
         //Test 3 begin -------------
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "31"])
@@ -177,7 +177,7 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("test3_part1.skd"));
         assert_eq!(true, sandbox.file_exists("test3_part1.skm"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("test3_part1")
@@ -278,7 +278,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("rfile.txt");
 
         // Sketch the files
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -290,7 +290,7 @@ mod tests {
             .success();
 
         // C-a dists at knn=1
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("sketch_db")
@@ -301,7 +301,7 @@ mod tests {
             .stdout_eq(sandbox.snapbox_file("dists_knn_ca.stdout", TestDir::Correct));
 
         // Jaccard dists at knn=1
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("sketch_db")
@@ -314,7 +314,7 @@ mod tests {
             .stdout_eq(sandbox.snapbox_file("dists_knn_jaccard.stdout", TestDir::Correct));
 
         // ANI dists at knn=1
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("sketch_db")
@@ -340,7 +340,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("rfile.txt");
 
         // Sketch the files
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -352,7 +352,7 @@ mod tests {
             .success();
 
         // Subset three samples and calc dists
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("dist")
             .arg("sketch_db")

--- a/tests/inverted.rs
+++ b/tests/inverted.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 pub mod common;
 use crate::common::*;
@@ -16,7 +16,7 @@ mod tests {
 
         sandbox.copy_input_file_to_wd("14412_3#82.contigs_velvet.fa.gz");
         sandbox.copy_input_file_to_wd("14412_3#84.contigs_velvet.fa.gz");
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("build")
@@ -30,7 +30,7 @@ mod tests {
 
         assert_eq!(true, sandbox.file_exists("inverted.ski"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("info")
             .arg("inverted.ski")
@@ -38,7 +38,7 @@ mod tests {
             .assert()
             .stdout_eq(sandbox.snapbox_file("inverted_sketch_info.stdout", TestDir::Correct));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("info")
             .arg("--sample-info")
@@ -56,7 +56,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("14412_3#84.contigs_velvet.fa.gz");
         sandbox.copy_input_file_to_wd("R6.fa.gz");
         sandbox.copy_input_file_to_wd("TIGR4.fa.gz");
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("build")
@@ -74,7 +74,7 @@ mod tests {
 
         assert_eq!(true, sandbox.file_exists("inverted.ski"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("info")
             .arg("inverted.ski")
@@ -98,7 +98,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("rfile.txt");
 
         // Build an inverted index
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("build")
@@ -111,7 +111,7 @@ mod tests {
             .success();
 
         // Query with the same samples, default is 'match-count'
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("query")
@@ -127,7 +127,7 @@ mod tests {
             );
 
         // Any bin matching gives two pairs
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("query")
@@ -144,7 +144,7 @@ mod tests {
             );
 
         // All matching gives self only
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("query")
@@ -173,7 +173,7 @@ mod tests {
         sandbox.copy_input_file_to_wd("rfile.txt");
 
         // Build an inverted index .ski and .skq
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("build")
@@ -195,7 +195,7 @@ mod tests {
         // See the match-count results in inverted_query_count.stdout
         // 14412_3#82.contigs_velvet.fa.gz and 14412_3#84.contigs_velvet.fa.gz match
         // R6.fa.gz and TIGR4.fa.gz match
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("precluster")
@@ -206,7 +206,7 @@ mod tests {
             .stdout_eq("Identified 2 prefilter pairs from a max of 6\n");
 
         // Build a standard .skd
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -218,7 +218,7 @@ mod tests {
             .success();
 
         // Run preclustering mode
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("precluster")
@@ -234,7 +234,7 @@ mod tests {
             );
 
         // Same with ANI
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("precluster")
@@ -251,7 +251,7 @@ mod tests {
             );
 
         // Default knn, check no junk distances printed
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("inverted")
             .arg("precluster")

--- a/tests/merge.rs
+++ b/tests/merge.rs
@@ -1,5 +1,5 @@
 use predicates::prelude::*;
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 use std::path::Path;
 
 pub mod common;
@@ -57,7 +57,7 @@ mod tests {
     fn test_merge_sketches() {
         let sandbox = TestSetup::setup();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -68,7 +68,7 @@ mod tests {
             .assert()
             .success();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -79,7 +79,7 @@ mod tests {
             .assert()
             .success();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .args(&["--k-vals", "17"])
@@ -93,7 +93,7 @@ mod tests {
             .success();
 
         // Overlapping labels fails
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("merge")
             .arg("part1")
@@ -103,7 +103,7 @@ mod tests {
             .assert()
             .failure();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("merge")
             .arg("part1")

--- a/tests/sketch.rs
+++ b/tests/sketch.rs
@@ -1,4 +1,4 @@
-use snapbox::cmd::{cargo_bin, Command};
+use snapbox::cmd::{self, Command};
 
 pub mod common;
 use crate::common::*;
@@ -12,7 +12,7 @@ mod tests {
     fn sketch_fasta() {
         let sandbox = TestSetup::setup();
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")
@@ -26,14 +26,14 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("assembly.skm"));
         assert_eq!(true, sandbox.file_exists("assembly.skd"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("info")
             .arg("assembly")
             .assert()
             .stdout_eq(sandbox.snapbox_file("assembly_sketch_info.stdout", TestDir::Correct));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("info")
             .arg("--sample-info")
@@ -49,7 +49,7 @@ mod tests {
 
         // Create a fastq rfile in the tmp dir
         let rfile_name = sandbox.create_fastq_rfile("test");
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-f")
@@ -63,14 +63,14 @@ mod tests {
         assert_eq!(true, sandbox.file_exists("reads.skm"));
         assert_eq!(true, sandbox.file_exists("reads.skd"));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("info")
             .arg("reads")
             .assert()
             .stdout_eq(sandbox.snapbox_file("read_sketch_info.stdout", TestDir::Correct));
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("info")
             .arg("--sample-info")
@@ -92,7 +92,7 @@ mod tests {
         // Old command:
         // sketchlib sketch -v -o legacy_db --k-vals 17,21,25 -s 100 R6.fa.gz TIGR4.fa.gz
 
-        Command::new(cargo_bin("sketchlib"))
+        Command::new(cmd::cargo_bin!("sketchlib"))
             .current_dir(sandbox.get_wd())
             .arg("sketch")
             .arg("-o")


### PR DESCRIPTION
See the deprecation notice in the [snapbox docs](https://docs.rs/snapbox/latest/snapbox/cmd/fn.cargo_bin.html).

fixes #60