### PR TITLE
Fix sample index mismatch between SKI and SKD in inverted precluster;…

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,24 @@ pub enum InvertedQueryType {
     AnyBins,
 }
 
+/// How to handle genomes with no shared bins in the prefilter
+#[derive(Clone, Debug, PartialEq, PartialOrd, ValueEnum)]
+pub enum RetainUnmatched {
+    /// Output unmatched genomes as self-matches (singletons)
+    Singleton,
+    /// Brute-force compare unmatched genomes against all others
+    Bruteforce,
+}
+
+impl fmt::Display for RetainUnmatched {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            RetainUnmatched::Singleton => write!(f, "Retain as singletons"),
+            RetainUnmatched::Bruteforce => write!(f, "Brute-force against all"),
+        }
+    }
+}
+
 impl fmt::Display for InvertedQueryType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -426,6 +444,11 @@ pub enum InvertedCommands {
         /// minimum completeness for a sample to be corrected but the completeness correction
         #[arg(long, default_value_t = 0.64)]
         completeness_cutoff: f64,
+
+        /// Retain genomes with no shared bins in the prefilter.
+        /// 'singleton' outputs them as self-matches, 'bruteforce' compares them against all others.
+        #[arg(long, value_enum)]
+        retain_unmatched: Option<RetainUnmatched>,
     },
 }
 

--- a/src/distances/mod.rs
+++ b/src/distances/mod.rs
@@ -6,6 +6,7 @@ use hashbrown::HashMap;
 use indicatif::ParallelProgressIterator;
 use rayon::prelude::*;
 
+use crate::cli::RetainUnmatched;
 use crate::get_progress_bar;
 use crate::inverted::Inverted;
 use crate::sketch::multisketch::MultiSketch;
@@ -307,23 +308,34 @@ pub fn self_dists_knn_precluster<'a>(
     quiet: bool,
     completeness_vec: Option<&Vec<f64>>,
     completeness_cutoff: f64,
+    retain_unmatched: &Option<RetainUnmatched>,
 ) -> SparseDistanceMatrix<'a> {
     // Check that sample sets in ski and skm are the same and create i,j lookup
     let mut skq_lookup = HashMap::with_capacity(n);
     for (skq_index, skq_sample) in inverted_index.sample_names().iter().enumerate() {
         skq_lookup.insert(skq_sample.as_str(), skq_index);
     }
+
     let mut not_found = Vec::new();
+    // Map: skd index to ski index
+    // Needed to convert i (from skd ordering) to ski ordering
     let mut skq_index_lookup = Vec::with_capacity(n);
     for skd_sample_idx in 0..sketches.number_samples_loaded() {
         let sample_name = sketches.sketch_name(skd_sample_idx);
         match skq_lookup.get(sample_name) {
-            Some(skq_index) => skq_index_lookup.push(skq_index),
+            Some(skq_index) => skq_index_lookup.push(*skq_index),
             None => not_found.push(sample_name),
         };
     }
     if !not_found.is_empty() {
         panic!("The following samples in the .skd could not be found in the .ski:\n{not_found:?}");
+    }
+
+    // Reverse map: ski index to skd index
+    // Needed to convert j (from inverted index, ski ordering) back to skd ordering
+    let mut skd_index_from_ski: Vec<usize> = vec![0; n];
+    for (skd_idx, &ski_idx) in skq_index_lookup.iter().enumerate() {
+        skd_index_from_ski[ski_idx] = skd_idx;
     }
 
     let mut sp_distances = SparseDistanceMatrix::new(sketches, knn, dist_type);
@@ -339,7 +351,7 @@ pub fn self_dists_knn_precluster<'a>(
                 .enumerate()
                 .for_each(|(i, row_dist_slice)| {
                     // Prefilter step here
-                    let skq_offset = i * skq_stride;
+                    let skq_offset = skq_index_lookup[i] * skq_stride;
                     let flat_i_sketch = &skq_bins[skq_offset..(skq_offset + skq_stride)];
                     let prefiltered_samples = inverted_index.any_shared_bins(flat_i_sketch);
                     // Standard search
@@ -347,17 +359,18 @@ pub fn self_dists_knn_precluster<'a>(
                     let i_sketch = sketches.get_sketch_slice(i, k_idx);
                     for j in prefiltered_samples {
                         let j = j as usize;
-                        if i == j {
+                        if skq_index_lookup[i] == j {
                             continue;
                         }
+                        let skd_j = skd_index_from_ski[j];
                         // If completeness_vec is Some, extract the value at index i (or j) from the inner vector.
                         // If completeness_vec is None, the result will also be None.
                         // This uses Option::map to safely access the completeness value for each sample.
                         let c1 = completeness_vec.map(|cv| cv[i]);
-                        let c2 = completeness_vec.map(|cv| cv[j]);
+                        let c2 = completeness_vec.map(|cv| cv[skd_j]);
                         let dist = jaccard_index(
                             i_sketch,
-                            sketches.get_sketch_slice(j, k_idx),
+                            sketches.get_sketch_slice(skd_j, k_idx),
                             sketches.sketchsize64,
                             c1,
                             c2,
@@ -368,10 +381,53 @@ pub fn self_dists_knn_precluster<'a>(
                         } else {
                             (1.0_f64 - dist) as f32
                         };
-                        let dist_item = SparseJaccard(j, dist_f32);
+                        let dist_item = SparseJaccard(skd_j, dist_f32);
                         push_heap(&mut heap, dist_item, knn);
                     }
                     let mut dist_vec = heap.into_sorted_vec();
+
+                    // Handle unmatched genomes (no prefiltered matches)
+                    if dist_vec.is_empty() {
+                        match retain_unmatched {
+                            Some(RetainUnmatched::Singleton) => {
+                                let mut singleton_vec = vec![SparseJaccard(i, 0.0)];
+                                singleton_vec.append(&mut vec![
+                                    SparseJaccard(i, 1.0);
+                                    row_dist_slice.len() - 1
+                                ]);
+                                row_dist_slice.clone_from_slice(&singleton_vec);
+                                return;
+                            }
+                            Some(RetainUnmatched::Bruteforce) => {
+                                let mut bf_heap = BinaryHeap::with_capacity(knn + 1);
+                                for j in 0..n {
+                                    if i == j {
+                                        continue;
+                                    }
+                                    let c1 = completeness_vec.map(|cv| cv[i]);
+                                    let c2 = completeness_vec.map(|cv| cv[j]);
+                                    let dist = jaccard_index(
+                                        i_sketch,
+                                        sketches.get_sketch_slice(j, k_idx),
+                                        sketches.sketchsize64,
+                                        c1,
+                                        c2,
+                                        completeness_cutoff,
+                                    );
+                                    let dist_f32 = if ani {
+                                        (1.0_f64 - ani_pois(dist, k_f64)) as f32
+                                    } else {
+                                        (1.0_f64 - dist) as f32
+                                    };
+                                    let dist_item = SparseJaccard(j, dist_f32);
+                                    push_heap(&mut bf_heap, dist_item, knn);
+                                }
+                                dist_vec = bf_heap.into_sorted_vec();
+                            }
+                            None => {}
+                        }
+                    }
+
                     if ani {
                         // Undo the above transform
                         dist_vec.iter_mut().for_each(|inverse_ani| {

--- a/src/io.rs
+++ b/src/io.rs
@@ -5,7 +5,6 @@ use crate::sketch::multisketch::MultiSketch;
 use std::fs::File;
 use std::io::{stdout, BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
-use std::sync::Mutex;
 
 use anyhow::Context;
 use hashbrown::{HashMap, HashSet};
@@ -217,7 +216,7 @@ pub fn read_completeness_file(
 ) -> Result<Vec<f64>, crate::Error> {
     // Pre-allocate vector with default values (1.0 for missing genomes)
     let mut completeness_vec = vec![1.0_f64; sketches.number_samples_loaded()];
-    let missing_genomes = Mutex::new(Vec::new());
+    let mut matched = vec![false; sketches.number_samples_loaded()];
 
     // Open file with buffered reader for streaming
     let f = File::open(completeness_file)
@@ -235,14 +234,7 @@ pub fn read_completeness_file(
         .filter_map(|line| {
             if let Some((genome_id, completeness_str)) = line.split_once('\t') {
                 if let Ok(completeness) = completeness_str.parse::<f64>() {
-                    // Use MultiSketch's method to get the logical index
-                    if let Some(index) = sketches.get_sample_index(genome_id) {
-                        Some((index, completeness))
-                    } else {
-                        // Track missing genomes
-                        missing_genomes.lock().unwrap().push(genome_id.to_string());
-                        None
-                    }
+                    sketches.get_sample_index(genome_id).map(|index| (index, completeness))
                 } else {
                     None
                 }
@@ -252,16 +244,22 @@ pub fn read_completeness_file(
         })
         .collect();
 
-    // Apply updates to completeness_vec (thread safe)
+    // Apply updates to completeness_vec
     for (index, completeness) in updates {
         completeness_vec[index] = completeness;
+        matched[index] = true;
     }
 
-    // Report missing genomes
-    let missing = missing_genomes.into_inner().unwrap();
+    // Report sketch genomes not found in completeness file
+    let missing: Vec<String> = matched
+        .iter()
+        .enumerate()
+        .filter(|(_, &m)| !m)
+        .map(|(i, _)| sketches.sketch_name(i).to_string())
+        .collect();
     if !missing.is_empty() {
         log::warn!(
-            "Found {} genomes not in completeness file, using default 1.0: {}",
+            "{} genome(s) not found in completeness file, using default 1.0: {}",
             missing.len(),
             missing.join(", ")
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,6 +554,7 @@ pub fn main() -> Result<(), Error> {
                 threads,
                 completeness_file,
                 completeness_cutoff,
+                retain_unmatched,
             } => {
                 check_and_set_threads(*threads);
 
@@ -629,6 +630,9 @@ pub fn main() -> Result<(), Error> {
                         kmer,
                         inverted_index.sketch_size()
                     );
+                    if let Some(ref mode) = retain_unmatched {
+                        log::info!("Retain unmatched mode: {mode}");
+                    }
                     let distances = self_dists_knn_precluster(
                         &references,
                         &inverted_index,
@@ -640,6 +644,7 @@ pub fn main() -> Result<(), Error> {
                         args.quiet,
                         completeness_vec.as_ref(),
                         *completeness_cutoff,
+                        retain_unmatched,
                     );
 
                     // Write the results

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -136,6 +136,22 @@ impl TestSetup {
         RFILE_NAME
     }
 
+    pub fn create_named_rfile(&self, rfile_name: &str, filenames: &[&str]) -> String {
+        let mut rfile = LineWriter::new(
+            File::create(format!("{}/{}", self.get_wd(), rfile_name))
+                .expect("Could not write rfile"),
+        );
+        for file in filenames {
+            writeln!(
+                rfile,
+                "{}",
+                &format!("{}\t{}", file, self.file_string(file, TestDir::Input),)
+            )
+            .unwrap();
+        }
+        rfile_name.to_string()
+    }
+
     /// Create an rfile wtih two fastqs in the tmp dir
     pub fn create_fastq_rfile(&self, prefix: &str) -> &str {
         let mut rfile = LineWriter::new(

--- a/tests/inverted.rs
+++ b/tests/inverted.rs
@@ -266,4 +266,541 @@ mod tests {
                     .unordered(),
             );
     }
+
+    // Helper to set up reordered SKI + standard SKD
+    // SKI order (via --species-names): TIGR4, R6, #82, #84
+    // SKD order (via rfile.txt):       #82, #84, R6, TIGR4
+    fn setup_reordered_precluster(sandbox: &TestSetup) {
+        sandbox.copy_input_file_to_wd("14412_3#82.contigs_velvet.fa.gz");
+        sandbox.copy_input_file_to_wd("14412_3#84.contigs_velvet.fa.gz");
+        sandbox.copy_input_file_to_wd("R6.fa.gz");
+        sandbox.copy_input_file_to_wd("TIGR4.fa.gz");
+        sandbox.copy_input_file_to_wd("rfile.txt");
+
+        // Build SKI+SKQ with reordered samples via --species-names
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("build")
+            .arg("-o")
+            .arg("reordered_inv")
+            .args(["-v", "-k", "21", "-s", "10"])
+            .arg("-f")
+            .arg("rfile.txt")
+            .arg("--write-skq")
+            .arg("--species-names")
+            .arg(sandbox.file_string("species_names.txt", TestDir::Input))
+            .assert()
+            .success();
+
+        // Build standard SKD (different sample order)
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("sketch")
+            .arg("-o")
+            .arg("standard")
+            .args(["-v", "--k-vals", "21", "-s", "1000"])
+            .arg("-f")
+            .arg("rfile.txt")
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn inverted_precluster_reordered() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        // Run preclustering with different SKI vs SKD orderings
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--skd")
+            .arg("standard")
+            .arg("reordered_inv.ski")
+            .assert()
+            .stdout_eq(
+                sandbox
+                    .snapbox_file("inverted_precluster.stdout", TestDir::Correct)
+                    .unordered(),
+            );
+    }
+
+    #[test]
+    fn inverted_precluster_reordered_ani() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--ani")
+            .arg("--skd")
+            .arg("standard")
+            .arg("reordered_inv.ski")
+            .assert()
+            .stdout_eq(
+                sandbox
+                    .snapbox_file("inverted_precluster_ani.stdout", TestDir::Correct)
+                    .unordered(),
+            );
+    }
+
+    #[test]
+    fn inverted_precluster_reordered_knn_padding() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        // knn=50 >> n_samples=4, tests padding with reordered indices
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "50"])
+            .arg("--skd")
+            .arg("standard")
+            .arg("reordered_inv.ski")
+            .assert()
+            .stdout_eq(
+                sandbox
+                    .snapbox_file("inverted_precluster.stdout", TestDir::Correct)
+                    .unordered(),
+            );
+    }
+
+    #[test]
+    fn inverted_precluster_reversed_rfile() {
+        let sandbox = TestSetup::setup();
+
+        sandbox.copy_input_file_to_wd("14412_3#82.contigs_velvet.fa.gz");
+        sandbox.copy_input_file_to_wd("14412_3#84.contigs_velvet.fa.gz");
+        sandbox.copy_input_file_to_wd("R6.fa.gz");
+        sandbox.copy_input_file_to_wd("TIGR4.fa.gz");
+
+        // Build SKI with reversed sample order
+        let reversed_rfile = sandbox.create_named_rfile(
+            "reversed_rfile.txt",
+            &[
+                "TIGR4.fa.gz",
+                "R6.fa.gz",
+                "14412_3#84.contigs_velvet.fa.gz",
+                "14412_3#82.contigs_velvet.fa.gz",
+            ],
+        );
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("build")
+            .arg("-o")
+            .arg("reversed_inv")
+            .args(["-v", "-k", "21", "-s", "10"])
+            .arg("-f")
+            .arg(&reversed_rfile)
+            .arg("--write-skq")
+            .assert()
+            .success();
+
+        // Build SKD with standard order
+        let standard_rfile = sandbox.create_named_rfile(
+            "standard_rfile.txt",
+            &[
+                "14412_3#82.contigs_velvet.fa.gz",
+                "14412_3#84.contigs_velvet.fa.gz",
+                "R6.fa.gz",
+                "TIGR4.fa.gz",
+            ],
+        );
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("sketch")
+            .arg("-o")
+            .arg("standard")
+            .args(["-v", "--k-vals", "21", "-s", "1000"])
+            .arg("-f")
+            .arg(&standard_rfile)
+            .assert()
+            .success();
+
+        // Run precluster with different orderings
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--skd")
+            .arg("standard")
+            .arg("reversed_inv.ski")
+            .assert()
+            .stdout_eq(
+                sandbox
+                    .snapbox_file("inverted_precluster.stdout", TestDir::Correct)
+                    .unordered(),
+            );
+    }
+
+    #[test]
+    fn inverted_precluster_reordered_completeness() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        // Create completeness file with asymmetric values
+        TestSetup::create_completeness_file(
+            &sandbox,
+            "completeness_reorder.txt",
+            &[
+                ("14412_3#82.contigs_velvet.fa.gz", 0.7),
+                ("14412_3#84.contigs_velvet.fa.gz", 0.8),
+                ("R6.fa.gz", 0.9),
+                ("TIGR4.fa.gz", 0.95),
+            ],
+        );
+
+        // Also build same-order SKI for comparison
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("build")
+            .arg("-o")
+            .arg("sameorder_inv")
+            .args(["-v", "-k", "21", "-s", "10"])
+            .arg("-f")
+            .arg("rfile.txt")
+            .arg("--write-skq")
+            .assert()
+            .success();
+
+        // Run with reordered SKI + completeness
+        let reordered_output = Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--skd")
+            .arg("standard")
+            .arg("--completeness-file")
+            .arg(sandbox.file_string("completeness_reorder.txt", TestDir::Output))
+            .arg("reordered_inv.ski")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        // Run with same-order SKI + completeness
+        let sameorder_output = Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--skd")
+            .arg("standard")
+            .arg("--completeness-file")
+            .arg(sandbox.file_string("completeness_reorder.txt", TestDir::Output))
+            .arg("sameorder_inv.ski")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        // Parse and compare: both orderings must produce the same distances
+        let mut reordered_lines: Vec<String> = String::from_utf8(reordered_output)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect();
+        let mut sameorder_lines: Vec<String> = String::from_utf8(sameorder_output)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect();
+        reordered_lines.sort();
+        sameorder_lines.sort();
+        assert_eq!(
+            reordered_lines, sameorder_lines,
+            "Reordered and same-order precluster with completeness should produce identical results"
+        );
+    }
+
+    #[test]
+    fn inverted_precluster_all_genomes_in_output() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        let input_names = [
+            "14412_3#82.contigs_velvet.fa.gz",
+            "14412_3#84.contigs_velvet.fa.gz",
+            "R6.fa.gz",
+            "TIGR4.fa.gz",
+        ];
+
+        // Run precluster
+        let output = Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--skd")
+            .arg("standard")
+            .arg("reordered_inv.ski")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let output_str = String::from_utf8(output).unwrap();
+        let mut found_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for line in output_str.lines().filter(|l| !l.is_empty()) {
+            let fields: Vec<&str> = line.split('\t').collect();
+            found_names.insert(fields[0]);
+            found_names.insert(fields[1]);
+        }
+
+        for name in &input_names {
+            assert!(
+                found_names.contains(name),
+                "Genome {name} missing from precluster output"
+            );
+        }
+        assert_eq!(
+            found_names.len(),
+            input_names.len(),
+            "Number of unique genomes in output ({}) does not match input ({})",
+            found_names.len(),
+            input_names.len(),
+        );
+    }
+
+    #[test]
+    fn inverted_precluster_self_skip() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        // knn=3 to get all possible neighbors
+        let output = Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "3"])
+            .arg("--skd")
+            .arg("standard")
+            .arg("reordered_inv.ski")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let output_str = String::from_utf8(output).unwrap();
+        for line in output_str.lines().filter(|l| !l.is_empty()) {
+            let fields: Vec<&str> = line.split('\t').collect();
+            assert!(
+                fields.len() >= 3,
+                "Output line should have at least 3 tab-separated fields: {line}"
+            );
+            // First two fields are sample names - they must not be the same
+            assert_ne!(
+                fields[0], fields[1],
+                "Self-comparison found in output: {line}"
+            );
+            // Distance should be between 0 and 1 exclusive
+            let dist: f64 = fields[2].parse().expect("Failed to parse distance");
+            assert!(
+                dist > 0.0 && dist < 1.0,
+                "Distance out of range (0,1): {dist} in line: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn inverted_precluster_retain_singleton() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        let input_names = [
+            "14412_3#82.contigs_velvet.fa.gz",
+            "14412_3#84.contigs_velvet.fa.gz",
+            "R6.fa.gz",
+            "TIGR4.fa.gz",
+        ];
+
+        let output = Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--retain-unmatched")
+            .arg("singleton")
+            .arg("--skd")
+            .arg("standard")
+            .arg("reordered_inv.ski")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let output_str = String::from_utf8(output).unwrap();
+        let mut found_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for line in output_str.lines().filter(|l| !l.is_empty()) {
+            let fields: Vec<&str> = line.split('\t').collect();
+            found_names.insert(fields[0]);
+            found_names.insert(fields[1]);
+            // Self-match lines should have distance 0
+            if fields[0] == fields[1] {
+                let dist: f64 = fields[2].parse().expect("Failed to parse distance");
+                assert_eq!(dist, 0.0, "Singleton self-match should have distance 0");
+            }
+        }
+
+        for name in &input_names {
+            assert!(
+                found_names.contains(name),
+                "Genome {name} missing from output with --retain-unmatched singleton"
+            );
+        }
+    }
+
+    #[test]
+    fn inverted_precluster_retain_bruteforce() {
+        let sandbox = TestSetup::setup();
+        setup_reordered_precluster(&sandbox);
+
+        let input_names = [
+            "14412_3#82.contigs_velvet.fa.gz",
+            "14412_3#84.contigs_velvet.fa.gz",
+            "R6.fa.gz",
+            "TIGR4.fa.gz",
+        ];
+
+        let output = Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("precluster")
+            .args(["-v", "--knn", "1"])
+            .arg("--retain-unmatched")
+            .arg("bruteforce")
+            .arg("--skd")
+            .arg("standard")
+            .arg("reordered_inv.ski")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        let output_str = String::from_utf8(output).unwrap();
+        let mut found_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for line in output_str.lines().filter(|l| !l.is_empty()) {
+            let fields: Vec<&str> = line.split('\t').collect();
+            found_names.insert(fields[0]);
+            found_names.insert(fields[1]);
+            // No self-matches in bruteforce mode
+            assert_ne!(
+                fields[0], fields[1],
+                "Self-comparison found in bruteforce output: {line}"
+            );
+            let dist: f64 = fields[2].parse().expect("Failed to parse distance");
+            assert!(
+                dist > 0.0 && dist < 1.0,
+                "Distance out of range (0,1): {dist} in line: {line}"
+            );
+        }
+
+        for name in &input_names {
+            assert!(
+                found_names.contains(name),
+                "Genome {name} missing from output with --retain-unmatched bruteforce"
+            );
+        }
+    }
+
+    #[test]
+    fn inverted_query_reordered() {
+        let sandbox = TestSetup::setup();
+
+        sandbox.copy_input_file_to_wd("14412_3#82.contigs_velvet.fa.gz");
+        sandbox.copy_input_file_to_wd("14412_3#84.contigs_velvet.fa.gz");
+        sandbox.copy_input_file_to_wd("R6.fa.gz");
+        sandbox.copy_input_file_to_wd("TIGR4.fa.gz");
+        sandbox.copy_input_file_to_wd("rfile.txt");
+
+        // Build reordered SKI
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("build")
+            .arg("-o")
+            .arg("reordered_inv")
+            .args(["-v", "-k", "21", "-s", "10"])
+            .arg("-f")
+            .arg("rfile.txt")
+            .arg("--species-names")
+            .arg(sandbox.file_string("species_names.txt", TestDir::Input))
+            .assert()
+            .success();
+
+        // Query with match-count
+        let output = Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("query")
+            .arg("-v")
+            .arg("-f")
+            .arg("rfile.txt")
+            .arg("reordered_inv.ski")
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+
+        // Verify self-matches are 10 and cross-group matches are 0
+        let output_str = String::from_utf8(output).unwrap();
+        for line in output_str.lines().skip(1).filter(|l| !l.is_empty()) {
+            let fields: Vec<&str> = line.split('\t').collect();
+            let query_name = fields[0];
+            // Find the self-match count (column matching the query name)
+            let header: Vec<&str> = output_str.lines().next().unwrap().split('\t').collect();
+            for (col_idx, &col_name) in header.iter().enumerate().skip(1) {
+                let count: u32 = fields[col_idx].parse().unwrap();
+                if col_name == query_name {
+                    assert_eq!(count, 10, "Self-match count should be 10 for {query_name}");
+                }
+            }
+        }
+
+        // Query with any-bins
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("query")
+            .arg("-v")
+            .arg("-f")
+            .arg("rfile.txt")
+            .arg("reordered_inv.ski")
+            .args(&["--query-type", "any-bins"])
+            .assert()
+            .success();
+
+        // Query with all-bins
+        Command::new(cargo_bin("sketchlib"))
+            .current_dir(sandbox.get_wd())
+            .arg("inverted")
+            .arg("query")
+            .arg("-v")
+            .arg("-f")
+            .arg("rfile.txt")
+            .arg("reordered_inv.ski")
+            .args(&["--query-type", "all-bins"])
+            .assert()
+            .success();
+    }
 }


### PR DESCRIPTION
… add --retain-unmatched option

  Fixes a bug where precluster produced incorrect filtering when the inverted
  index (SKI) and sketch database (SKD) had different sample orderings:
  prefilter bins were looked up at the wrong offset, and SKI indices were
  used directly as SKD indices when fetching sketches, completeness values,
  and output names. Adds forward/reverse index maps to correctly translate
  between SKI and SKD orderings.

  Also adds --retain-unmatched flag to handle genomes with no prefilter
  matches, either as singletons or via brute-force comparison. Includes
  tests for both fixes.