### PR TITLE
Sketching api for sequence data passed via an iterator

### DIFF
--- a/src/hashing/aahash_iterator.rs
+++ b/src/hashing/aahash_iterator.rs
@@ -1,6 +1,4 @@
 //! Functions to support `aaHash` generation over sequences
-#[cfg(not(target_arch = "wasm32"))]
-use needletail::parse_fastx_file;
 
 use std::cmp::Ordering;
 

--- a/src/hashing/aahash_iterator.rs
+++ b/src/hashing/aahash_iterator.rs
@@ -80,24 +80,26 @@ impl AaHashIterator {
         }
     }
 
-    /// Create a new aaHash iterator from a fasta file, at the set comparison level
-    pub fn new(files: &[String], level: AaLevel, concat_fasta: bool) -> Vec<Self> {
+    /// Create a new aaHash iterator from a fastX reader, at the set comparison level
+    pub fn new<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
+        readers: &mut [I],
+        file: &String,
+        level: AaLevel,
+        concat_fasta: bool
+    ) -> Vec<Self> {
         let mut hash_vec = Vec::new();
 
         // Read sequence into memory (as we go through multiple times)
         log::debug!("Preprocessing sequence");
         let mut seq_hash_it = Self::default(level.clone());
-        for file in files.iter() {
-            let mut reader =
-                parse_fastx_file(file).unwrap_or_else(|_| panic!("Invalid path/file: {file}"));
+        for reader in readers.iter_mut() {
             loop {
                 let record_read = reader.next();
                 if let Some(record) = record_read {
-                    let seqrec = record.expect("Invalid FASTA/Q record");
-                    if seqrec.qual().is_some() {
+                    if record.1.is_some() {
                         panic!("Unexpected quality information with AA sequences in {file}. Correct sequence type set?");
                     } else {
-                        for aa in seqrec.seq().iter() {
+                        for aa in record.0.iter() {
                             if valid_aa(*aa) {
                                 seq_hash_it.seq.push(*aa)
                             } else {
@@ -124,8 +126,11 @@ impl AaHashIterator {
     }
 
     /// Create a new iterator from a 3di embedding file of a structure
-    pub fn from_3di_file(files: &[String]) -> Vec<Self> {
-        Self::new(files, AaLevel::Level1, false)
+    pub fn from_3di_file<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
+        readers: &mut [I],
+        file: &String,
+    ) -> Vec<Self> {
+        Self::new(readers, file, AaLevel::Level1, false)
     }
 
     /// Create a new iterator from a 3di embedding string of a structure

--- a/src/hashing/nthash_iterator.rs
+++ b/src/hashing/nthash_iterator.rs
@@ -1,6 +1,4 @@
 //! Functions to support `ntHash` generation over sequences
-#[cfg(not(target_arch = "wasm32"))]
-use needletail::{parse_fastx_file, parser::Format};
 
 #[cfg(target_arch = "wasm32")]
 use crate::fastx_wasm::{open_fasta, open_fastq};
@@ -91,21 +89,13 @@ impl RollHash for NtHashIterator {
 impl NtHashIterator {
     #[cfg(not(target_arch = "wasm32"))]
     /// Creates a new ntHash iterator, by loading DNA sequences into memory
-    pub fn new(files: &[String], k: usize, rc: bool, min_qual: u8) -> Vec<Self> {
-        // Check if we're working with reads, and initalise the filter if so
-        let mut reader_peek = parse_fastx_file(files[0].clone())
-            .unwrap_or_else(|_| panic!("Invalid path/file: {}", files[0]));
-        let seq_peek = reader_peek
-            .next()
-            .expect("Invalid FASTA/Q record")
-            .expect("Invalid FASTA/Q record");
-        let mut reads = false;
-        if seq_peek.format() == Format::Fastq {
-            reads = true;
-            if files.len() > 2 {
-                panic!("Input files are reads, but there are more than two input files");
-            }
-        }
+    pub fn new<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
+        files: &mut [I],
+        k: usize,
+        rc: bool,
+        min_qual: u8,
+        reads: bool,
+    ) -> Vec<Self> {
 
         let mut seq = Vec::new();
         let mut offsets = Vec::new();
@@ -114,7 +104,7 @@ impl NtHashIterator {
 
         // Read sequence into memory (as we go through multiple times)
         log::debug!("Preprocessing sequence");
-        for file in files.iter() {
+        for file in files.iter_mut() {
             Self::add_dna_seq(
                 file,
                 min_qual,
@@ -202,28 +192,26 @@ impl NtHashIterator {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    fn add_dna_seq(
-        filename: &str,
+    fn add_dna_seq<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
+        records: &mut I,
         min_qual: u8,
         seq: &mut Vec<u8>,
         offsets: &mut Vec<usize>,
         acgt: &mut [usize; 4],
         non_acgt: &mut usize,
     ) {
-        let mut reader =
-            parse_fastx_file(filename).unwrap_or_else(|_| panic!("Invalid path/file: {filename}"));
 
         // Current byte
         let mut b = 0;
         // Nucleotide index within byte 0-3
         let mut i = 0;
 
-        while let Some(record) = reader.next() {
-            let seqrec = record.expect("Invalid FASTA/Q record");
-
-            for (base_idx, base) in seqrec.seq().iter().enumerate() {
-                if valid_base(*base) && seqrec.qual().is_none_or(|q| q[base_idx] >= min_qual) {
-                    let encoded_base = encode_base(*base);
+        for record in records {
+            let bases_iter = record.0.into_iter();
+            let qual = record.1;
+            for (base_idx, base) in bases_iter.enumerate() {
+                if valid_base(base) && qual.as_ref().is_none_or(|q| q[base_idx] >= min_qual) {
+                    let encoded_base = encode_base(base);
                     acgt[encoded_base as usize] += 1;
                     b |= encoded_base;
                     i += 1;

--- a/src/inverted.rs
+++ b/src/inverted.rs
@@ -333,10 +333,32 @@ impl Inverted {
                     .progress_with(progress_bar)
                     .map(|((name, fastxvec), genome_idx)| {
                         let mut hash_its: Vec<Box<dyn RollHash>> = match seq_type {
-                            HashType::DNA => NtHashIterator::new(fastxvec, k, rc, min_qual)
+                            HashType::DNA => {
+                            // Check if we're working with reads, and initalise the filter if so
+                            let mut reader_peek = needletail::parse_fastx_file(fastxvec[0].clone())
+                                .unwrap_or_else(|_| panic!("Invalid path/file: {}", fastxvec[0]));
+                            let seq_peek = reader_peek
+                                .next()
+                                .expect("Invalid FASTA/Q record")
+                                .expect("Invalid FASTA/Q record");
+                            let mut reads = false;
+                            if seq_peek.format() == needletail::parser::Format::Fastq {
+                                reads = true;
+                                if fastxvec.len() > 2 {
+                                    panic!("Input files are reads, but there are more than two input files");
+                                }
+                            }
+
+                            let mut records_readers = fastxvec.iter().map(|file| {
+                                let reader = needletail::parse_fastx_file(file).unwrap_or_else(|_| panic!("Invalid path/file: {file}"));
+                                crate::io::NeedletailIterator::new(reader)
+                            }).collect::<Vec<crate::io::NeedletailIterator>>();
+
+                                NtHashIterator::new(&mut records_readers, k, rc, min_qual, reads)
                                 .into_iter()
                                 .map(|it| Box::new(it) as Box<dyn RollHash>)
-                                .collect(),
+                                .collect()
+                            },
                             _ => unimplemented!("Inverted index only supported for DNA"),
                         };
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -15,6 +15,38 @@ use regex::Regex;
 /// Wrapper type for the three fields in an rfile
 pub type InputFastx = (String, Vec<String>);
 
+/// Iterator for needletail records
+#[cfg(not(target_arch = "wasm32"))]
+pub struct NeedletailIterator {
+    reader: Box<dyn needletail::FastxReader>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl NeedletailIterator {
+    /// Construct from needletail readers
+    pub fn new(
+        reader: Box<dyn needletail::FastxReader>,
+    ) -> Self {
+        Self {
+            reader,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Iterator for NeedletailIterator {
+    type Item = (Vec<u8>, Option<Vec<u8>>);
+
+    fn next(
+        &mut self,
+    ) -> Option<(Vec<u8>, Option<Vec<u8>>)> {
+        let record = self.reader.next()?.expect("Invalid FASTA/Q record");
+        let seq = record.seq();
+        let qual = record.qual().map(|qual| qual.to_vec());
+        Some((seq.to_vec(), qual))
+    }
+}
+
 /// Given a list of input files, parses them into triples of name, filename and
 /// [`None`] to be used as sketch input.
 pub fn read_input_fastas(seq_files: &[String]) -> Vec<InputFastx> {

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -7,6 +7,10 @@ use std::sync::mpsc;
 #[cfg(not(target_arch = "wasm32"))]
 use indicatif::ParallelProgressIterator;
 #[cfg(not(target_arch = "wasm32"))]
+use needletail::parse_fastx_file;
+#[cfg(not(target_arch = "wasm32"))]
+use needletail::parser::Format;
+#[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +23,8 @@ use super::hashing::{nthash_iterator::NtHashIterator, HashType};
 use crate::hashing::aahash_iterator::AaHashIterator;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::io::InputFastx;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::io::NeedletailIterator;
 #[cfg(feature = "3di")]
 use crate::structures::pdb_to_3di;
 #[cfg(not(target_arch = "wasm32"))]
@@ -396,14 +402,14 @@ pub fn sketch_files(
 
                     let reads = if seq_type == &HashType::DNA {
                         // Check if we're working with reads, and initalise the filter if so
-                        let mut reader_peek = needletail::parse_fastx_file(fastxvec[0].clone())
+                        let mut reader_peek = parse_fastx_file(fastxvec[0].clone())
                             .unwrap_or_else(|_| panic!("Invalid path/file: {}", fastxvec[0]));
                         let seq_peek = reader_peek
                             .next()
                             .expect("Invalid FASTA/Q record")
                             .expect("Invalid FASTA/Q record");
                         let mut reads = false;
-                        if seq_peek.format() == needletail::parser::Format::Fastq {
+                        if seq_peek.format() == Format::Fastq {
                             reads = true;
                             if fastxvec.len() > 2 {
                                 panic!("Input files are reads, but there are more than two input files");
@@ -415,9 +421,9 @@ pub fn sketch_files(
                     };
 
                     let mut records_readers = fastxvec.iter().map(|file| {
-                        let reader = needletail::parse_fastx_file(file).unwrap_or_else(|_| panic!("Invalid path/file: {file}"));
-                        crate::io::NeedletailIterator::new(reader)
-                    }).collect::<Vec<crate::io::NeedletailIterator>>();
+                        let reader = parse_fastx_file(file).unwrap_or_else(|_| panic!("Invalid path/file: {file}"));
+                        NeedletailIterator::new(reader)
+                    }).collect::<Vec<NeedletailIterator>>();
 
                     let di = struct_strings.as_ref().map(|structs| structs[idx].clone());
 

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -59,6 +59,46 @@ pub fn num_bins(sketch_size: u64) -> (u64, u64, u64) {
     (sketchsize64, signs_size, usigs_size)
 }
 
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+/// Options and parameters used in sketching
+pub struct SketchingOpts {
+    /// Sample name
+    pub name: String,
+    /// Concatenate records in a multifasta file?
+    pub concat_fasta: bool,
+    /// k-mer sizes to use
+    pub k_vals: Vec<usize>,
+    /// Sketch size
+    pub sketch_size: u64,
+    /// Sequence type (DNA, AA)
+    pub seq_type: HashType,
+    /// Add reverse complements to sketch?
+    pub add_rc: bool,
+    /// Minimum k-mer count to use for fastq input
+    pub min_count: u16,
+    /// Minimum quality score to use for fastq input
+    pub min_qual: u8,
+    /// Is the input reads?
+    pub is_reads: bool,
+}
+
+impl Default for SketchingOpts {
+    fn default() -> SketchingOpts {
+        SketchingOpts {
+            name: String::new(),
+            concat_fasta: false,
+            k_vals: Vec::new(),
+            sketch_size: crate::cli::DEFAULT_SKETCHSIZE,
+            seq_type: HashType::DNA,
+            add_rc: crate::cli::DEFAULT_STRAND,
+            min_count: crate::cli::DEFAULT_MINCOUNT,
+            min_qual: crate::cli::DEFAULT_MINQUAL,
+            is_reads: false,
+        }
+    }
+}
+
 /// A single sample's sketch
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Sketch {
@@ -287,45 +327,45 @@ impl fmt::Display for Sketch {
 /// Create sketches from an iterator over sequence data
 pub fn sketch_data<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
     records_readers: &mut [I],
-    name: &String,
-    concat_fasta: bool,
-    #[cfg(feature = "3di")] convert_pdb: bool,
-    k: &[usize],
-    sketch_size: u64,
-    seq_type: &HashType,
-    rc: bool,
-    min_count: u16,
-    min_qual: u8,
-    reads: bool,
+    opts: SketchingOpts,
+    #[cfg(feature = "3di")]
+    convert_pdb: bool,
+    #[cfg(feature = "3di")]
     struct_string: Option<String>,
 ) -> Vec<Sketch> {
     // Read in sequence and set up rolling hash by alphabet type
-    let mut hash_its: Vec<Box<dyn RollHash>> = match seq_type {
+    let mut hash_its: Vec<Box<dyn RollHash>> = match opts.seq_type {
         HashType::DNA => {
 
-            NtHashIterator::new(records_readers, k[0], rc, min_qual, reads)
+            NtHashIterator::new(records_readers, opts.k_vals[0], opts.add_rc, opts.min_qual, opts.is_reads)
                 .into_iter()
                 .map(|it| Box::new(it) as Box<dyn RollHash>)
                 .collect()
         },
         HashType::AA(level) => {
-            AaHashIterator::new(records_readers, name, level.clone(), concat_fasta)
+            AaHashIterator::new(records_readers, &opts.name, level.clone(), opts.concat_fasta)
                 .into_iter()
                 .map(|it| Box::new(it) as Box<dyn RollHash>)
                 .collect()
         }
         HashType::PDB => {
+            #[cfg(feature = "3di")]
             if let Some(di) = &struct_string {
                 AaHashIterator::from_3di_string(di.clone()) // TODO: clone is not ideal
                     .into_iter()
                     .map(|it| Box::new(it) as Box<dyn RollHash>)
                     .collect()
             } else {
-                AaHashIterator::from_3di_file(records_readers, name)
+                AaHashIterator::from_3di_file(records_readers, &opts.name)
                     .into_iter()
                     .map(|it| Box::new(it) as Box<dyn RollHash>)
                     .collect()
             }
+            #[cfg(not(feature = "3di"))]
+            AaHashIterator::from_3di_file(records_readers, &opts.name)
+                .into_iter()
+                .map(|it| Box::new(it) as Box<dyn RollHash>)
+                .collect()
         }
     };
 
@@ -333,16 +373,16 @@ pub fn sketch_data<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
         .iter_mut()
         .enumerate()
         .map(|(idx, hash_it)| {
-            let sample_name = if concat_fasta {
-                format!("{name}_{}", idx + 1)
+            let sample_name = if opts.concat_fasta {
+                format!("{}_{}", &opts.name, idx + 1)
             } else {
-                name.to_string()
+                opts.name.to_string()
             };
             if hash_it.seq_len() == 0 {
                 panic!("{sample_name} has no valid sequence");
             }
             // Run the sketching
-            Sketch::new(&mut **hash_it, &sample_name, k, sketch_size, rc, min_count)
+            Sketch::new(&mut **hash_it, &sample_name, &opts.k_vals, opts.sketch_size, opts.add_rc, opts.min_count)
         })
         .collect::<Vec<Sketch>>()
 }
@@ -374,9 +414,7 @@ pub fn sketch_files(
     } else {
         None
     };
-    #[cfg(not(feature = "3di"))]
-    let struct_strings: Option<Vec<String>> = None;
-
+    #[cfg(feature = "3di")]
     log::trace!("{struct_strings:?}");
 
     // Open output file
@@ -397,7 +435,7 @@ pub fn sketch_files(
                 .par_iter()
                 .progress_with(progress_bar)
                 .enumerate()
-                .map(|(idx, (name, fastxvec))| {
+                .map(|(_idx, (name, fastxvec))| {
                     // Read in sequence and set up rolling hash by alphabet type
 
                     let reads = if seq_type == &HashType::DNA {
@@ -420,26 +458,32 @@ pub fn sketch_files(
                         false
                     };
 
+                    let opts = SketchingOpts {
+                        name: name.clone(),
+                        k_vals: k.to_vec(),
+                        seq_type: seq_type.clone(),
+                        is_reads: reads,
+                        concat_fasta,
+                        sketch_size,
+                        add_rc: rc,
+                        min_count,
+                        min_qual,
+                    };
+
                     let mut records_readers = fastxvec.iter().map(|file| {
                         let reader = parse_fastx_file(file).unwrap_or_else(|_| panic!("Invalid path/file: {file}"));
                         NeedletailIterator::new(reader)
                     }).collect::<Vec<NeedletailIterator>>();
 
-                    let di = struct_strings.as_ref().map(|structs| structs[idx].clone());
+                    #[cfg(feature = "3di")]
+                    let di = struct_strings.as_ref().map(|structs| structs[_idx].clone());
 
                     sketch_data(
                         &mut records_readers,
-                        name,
-                        concat_fasta,
+                        opts,
                         #[cfg(feature = "3di")]
                         convert_pdb,
-                        k,
-                        sketch_size,
-                        seq_type,
-                        rc,
-                        min_count,
-                        min_qual,
-                        reads,
+                        #[cfg(feature = "3di")]
                         di,
                     )
                 })

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -278,6 +278,69 @@ impl fmt::Display for Sketch {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+pub fn sketch_data<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
+    records_readers: &mut [I],
+    name: &String,
+    concat_fasta: bool,
+    #[cfg(feature = "3di")] convert_pdb: bool,
+    k: &[usize],
+    sketch_size: u64,
+    seq_type: &HashType,
+    rc: bool,
+    min_count: u16,
+    min_qual: u8,
+    reads: bool,
+    struct_string: Option<String>,
+) -> Vec<Sketch> {
+    // Read in sequence and set up rolling hash by alphabet type
+    let mut hash_its: Vec<Box<dyn RollHash>> = match seq_type {
+        HashType::DNA => {
+
+            NtHashIterator::new(records_readers, k[0], rc, min_qual, reads)
+                .into_iter()
+                .map(|it| Box::new(it) as Box<dyn RollHash>)
+                .collect()
+        },
+        HashType::AA(level) => {
+            AaHashIterator::new(records_readers, name, level.clone(), concat_fasta)
+                .into_iter()
+                .map(|it| Box::new(it) as Box<dyn RollHash>)
+                .collect()
+        }
+        HashType::PDB => {
+            if let Some(di) = &struct_string {
+                AaHashIterator::from_3di_string(di.clone()) // TODO: clone is not ideal
+                    .into_iter()
+                    .map(|it| Box::new(it) as Box<dyn RollHash>)
+                    .collect()
+            } else {
+                AaHashIterator::from_3di_file(records_readers, name)
+                    .into_iter()
+                    .map(|it| Box::new(it) as Box<dyn RollHash>)
+                    .collect()
+            }
+        }
+    };
+
+    hash_its
+        .iter_mut()
+        .enumerate()
+        .map(|(idx, hash_it)| {
+            let sample_name = if concat_fasta {
+                format!("{name}_{}", idx + 1)
+            } else {
+                name.to_string()
+            };
+            if hash_it.seq_len() == 0 {
+                panic!("{sample_name} has no valid sequence");
+            }
+            // Run the sketching
+            Sketch::new(&mut **hash_it, &sample_name, k, sketch_size, rc, min_count)
+        })
+        .collect::<Vec<Sketch>>()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 /// Main function to create sketches from a set of input files, which is parallelised
 /// over the input files
 pub fn sketch_files(
@@ -329,49 +392,53 @@ pub fn sketch_files(
                 .enumerate()
                 .map(|(idx, (name, fastxvec))| {
                     // Read in sequence and set up rolling hash by alphabet type
-                    let mut hash_its: Vec<Box<dyn RollHash>> = match seq_type {
-                        HashType::DNA => NtHashIterator::new(fastxvec, k[0], rc, min_qual)
-                            .into_iter()
-                            .map(|it| Box::new(it) as Box<dyn RollHash>)
-                            .collect(),
-                        HashType::AA(level) => {
-                            AaHashIterator::new(fastxvec, level.clone(), concat_fasta)
-                                .into_iter()
-                                .map(|it| Box::new(it) as Box<dyn RollHash>)
-                                .collect()
-                        }
-                        HashType::PDB => {
-                            if let Some(di) = &struct_strings {
-                                log::trace!("Length of string: {}", di.len());
-                                AaHashIterator::from_3di_string(di[idx].clone()) // TODO: clone is not ideal
-                                    .into_iter()
-                                    .map(|it| Box::new(it) as Box<dyn RollHash>)
-                                    .collect()
-                            } else {
-                                AaHashIterator::from_3di_file(fastxvec)
-                                    .into_iter()
-                                    .map(|it| Box::new(it) as Box<dyn RollHash>)
-                                    .collect()
+
+                    let reads = if seq_type == &HashType::DNA {
+                        // Check if we're working with reads, and initalise the filter if so
+                        let mut reader_peek = needletail::parse_fastx_file(fastxvec[0].clone())
+                            .unwrap_or_else(|_| panic!("Invalid path/file: {}", fastxvec[0]));
+                        let seq_peek = reader_peek
+                            .next()
+                            .expect("Invalid FASTA/Q record")
+                            .expect("Invalid FASTA/Q record");
+                        let mut reads = false;
+                        if seq_peek.format() == needletail::parser::Format::Fastq {
+                            reads = true;
+                            if fastxvec.len() > 2 {
+                                panic!("Input files are reads, but there are more than two input files");
                             }
                         }
+                        reads
+                    } else {
+                        false
                     };
 
-                    hash_its
-                        .iter_mut()
-                        .enumerate()
-                        .map(|(idx, hash_it)| {
-                            let sample_name = if concat_fasta {
-                                format!("{name}_{}", idx + 1)
-                            } else {
-                                name.to_string()
-                            };
-                            if hash_it.seq_len() == 0 {
-                                panic!("{sample_name} has no valid sequence");
-                            }
-                            // Run the sketching
-                            Sketch::new(&mut **hash_it, &sample_name, k, sketch_size, rc, min_count)
-                        })
-                        .collect::<Vec<Sketch>>()
+                    let mut records_readers = fastxvec.iter().map(|file| {
+                        let reader = needletail::parse_fastx_file(file).unwrap_or_else(|_| panic!("Invalid path/file: {file}"));
+                        crate::io::NeedletailIterator::new(reader)
+                    }).collect::<Vec<crate::io::NeedletailIterator>>();
+
+                    let di = if let Some(structs) = &struct_strings {
+                        Some(structs[idx].clone())
+                    } else {
+                        None
+                    };
+
+                    sketch_data(
+                        &mut records_readers,
+                        name,
+                        concat_fasta,
+                        #[cfg(feature = "3di")]
+                        convert_pdb,
+                        k,
+                        sketch_size,
+                        seq_type,
+                        rc,
+                        min_count,
+                        min_qual,
+                        reads,
+                        di,
+                    )
                 })
                 .for_each_with(tx, |tx, sketch| {
                     // Emit the sketch results to the writer thread

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -278,6 +278,7 @@ impl fmt::Display for Sketch {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+/// Create sketches from an iterator over sequence data
 pub fn sketch_data<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
     records_readers: &mut [I],
     name: &String,
@@ -418,11 +419,7 @@ pub fn sketch_files(
                         crate::io::NeedletailIterator::new(reader)
                     }).collect::<Vec<crate::io::NeedletailIterator>>();
 
-                    let di = if let Some(structs) = &struct_strings {
-                        Some(structs[idx].clone())
-                    } else {
-                        None
-                    };
+                    let di = struct_strings.as_ref().map(|structs| structs[idx].clone());
 
                     sketch_data(
                         &mut records_readers,

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -17,7 +17,8 @@ use serde::{Deserialize, Serialize};
 use super::hashing::{bloom_filter::KmerFilter, RollHash};
 
 #[cfg(not(target_arch = "wasm32"))]
-use super::hashing::{nthash_iterator::NtHashIterator, HashType};
+use super::hashing::nthash_iterator::NtHashIterator;
+use super::hashing::HashType;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::hashing::aahash_iterator::AaHashIterator;

--- a/src/sketch/mod.rs
+++ b/src/sketch/mod.rs
@@ -326,6 +326,86 @@ impl fmt::Display for Sketch {
 
 #[cfg(not(target_arch = "wasm32"))]
 /// Create sketches from an iterator over sequence data
+///
+/// # Examples
+///
+/// ## Filter an assembly and sketch only some contigs
+/// ```rust
+/// use sketchlib::sketch::{Sketch, SketchingOpts};
+/// use sketchlib::sketch::sketch_data;
+///
+/// use std::collections::HashSet;
+/// use std::path::{Path, PathBuf};
+///
+/// // Iterator for needletail records
+/// pub struct NeedletailFilterIterator {
+///     reader: Box<dyn needletail::FastxReader>,
+///     want_ids: HashSet<u32>,
+///     current_idx: u32,
+/// }
+///
+/// impl NeedletailFilterIterator {
+///     // Construct from needletail readers
+///     pub fn new(
+///         reader: Box<dyn needletail::FastxReader>,
+///         want_ids: HashSet<u32>,
+///     ) -> Self {
+///         Self {
+///             reader,
+///             want_ids,
+///             current_idx: 0_u32,
+///         }
+///     }
+/// }
+///
+/// impl Iterator for NeedletailFilterIterator {
+///     type Item = (Vec<u8>, Option<Vec<u8>>);
+///
+///     fn next(
+///         &mut self,
+///     ) -> Option<(Vec<u8>, Option<Vec<u8>>)> {
+///         while let Some(try_record) = self.reader.next() {
+///             if self.want_ids.contains(&self.current_idx) {
+///                 let record = try_record.expect("Invalid fastX record");
+///                 let seq = record.seq();
+///                 let qual = record.qual().map(|qual| qual.to_vec());
+///                 self.current_idx += 1;
+///                 return Some((seq.to_vec(), qual))
+///             }
+///             self.current_idx += 1;
+///         }
+///         None
+///     }
+/// }
+///
+/// // Sketch a fastX file filtered by the index of reads to include in the sketch
+/// pub fn sketch_reads_with_filter(
+///     fastx_path: &Path,
+///     want_ids: HashSet<u32>,
+///     opts: SketchingOpts,
+/// ) -> Vec<Sketch> {
+///     let reader = needletail::parse_fastx_file(fastx_path).unwrap();
+///     let mut filtered_iters = vec![NeedletailFilterIterator::new(reader, want_ids)];
+///
+///     sketch_data(&mut filtered_iters, opts)
+/// }
+///
+/// let fastq_path_str = "tests/test_files_in/14412_3#82.contigs_velvet.fa.gz";
+/// let mut fastq_path = PathBuf::from(fastq_path_str);
+///
+/// let mut opts = SketchingOpts::default();
+/// opts.k_vals = vec![21_usize, 31_usize, 51_usize];
+/// opts.name = fastq_path_str.to_string();
+/// # opts.sketch_size = 1;
+///
+/// let want_ids: HashSet<u32> = HashSet::from_iter(vec![0_32, 5_u32, 3_u32].into_iter());
+/// let sketch = sketch_reads_with_filter(&fastq_path, want_ids, opts);
+///
+/// # let mut sketch = sketch;
+/// # assert_eq!(sketch.len(), 1);
+/// # assert_eq!(sketch[0].get_usigs(), vec![10446655729443322257_u64, 4179589106973994628, 8878020266243511022, 15496134240677377755, 12077142249206779756, 2557808496963489941, 11187838061323059739, 2644643690855717913, 4938295307178618234, 3755990044489396820, 5853149455415045639, 13413802265437751679, 13026670255550945707, 17600625581895810275, 15514998287561100248, 16224101823335952861, 7650478683895450690, 12490835276570242802, 16446545056545572452, 9136098023486151969, 14353135930022752998, 17596669057648315390, 13032397772767758586, 14311172789545189524, 8634896743882272518, 13813990681410911957, 15274287431720689540, 17130711307909519409, 14074157117691102709, 3977024316243443606, 11614473757740315713, 8590442866276072648, 3525327762139029339, 7654958233148978252, 14646652205652799167, 5876269956202259935, 16360345219485058576, 15734568599691562397, 11148612413168737116, 11587453912179871137, 2605646798685730264, 3886875076450406060]);
+/// # assert_eq!(sketch[0].name(), fastq_path_str);
+/// ```
 pub fn sketch_data<I: Iterator<Item=(Vec<u8>, Option<Vec<u8>>)>>(
     records_readers: &mut [I],
     opts: SketchingOpts,

--- a/src/sketch/multisketch.rs
+++ b/src/sketch/multisketch.rs
@@ -85,6 +85,10 @@ impl MultiSketch {
         kmer_lengths: &[usize],
         hash_type: HashType,
     ) -> Self {
+        for (idx, sketch) in sketches.iter_mut().enumerate() {
+            sketch.set_index(idx);
+        }
+
         let mut name_map = HashMap::with_capacity(sketches.len());
         for sketch in sketches.iter() {
             name_map.insert(sketch.name().to_string(), sketch.get_index());

--- a/src/sketch/multisketch.rs
+++ b/src/sketch/multisketch.rs
@@ -76,6 +76,44 @@ impl MultiSketch {
         }
     }
 
+    /// Create a new container for a `Vec<Sketch>`, emptying the Vec.
+    ///
+    /// Saves the data
+    pub fn from_sketches(
+        sketches: &mut Vec<Sketch>,
+        sketch_size: u64,
+        kmer_lengths: &[usize],
+        hash_type: HashType,
+    ) -> Self {
+        let mut name_map = HashMap::with_capacity(sketches.len());
+        for sketch in sketches.iter() {
+            name_map.insert(sketch.name().to_string(), sketch.get_index());
+        }
+
+        debug_assert!(sketch_size.is_multiple_of(u64::BITS as u64));
+        let (sketchsize64, _signs_size, usigs_size) = num_bins(sketch_size);
+        let kmer_stride = usigs_size as usize;
+
+        let sketch_bins = sketches.iter_mut().flat_map(|sketch| {
+            sketch.get_usigs()
+        }).collect();
+
+        Self {
+            sketch_size,
+            sketchsize64,
+            kmer_lengths: kmer_lengths.to_vec(),
+            sketch_metadata: std::mem::take(sketches),
+            name_map,
+            block_reindex: None,
+            sketch_bins,
+            bin_stride: 1,
+            kmer_stride,
+            sample_stride: kmer_stride * kmer_lengths.len(),
+            sketch_version: env!("CARGO_PKG_VERSION").to_string(),
+            hash_type,
+        }
+    }
+
     /// Saves the metadata (.skm)
     pub fn save_metadata(&self, file_prefix: &str) -> Result<(), Error> {
         let filename = format!("{file_prefix}.skm");


### PR DESCRIPTION
as discussed in #75

This breaks backwards compatibility for code that relies on the NtHashIterator::new or AaHashIterator::new constructor, let me know if this is a problem as it's possible to implement the PR with the old, now unused, constructors intact.

I didn't end up doing the PathBuf rewrite as strings are used everywhere else in the code to point to files so thought it'd be better to keep everything consistent.

btw needletail >=0.6 compiles for wasm32 if you only enable the flate2 compression, I think this would allow merging some of the wasm32 and non-wasm32 code if you want to simplify things at some point.

## Changes
Adds the following non-wasm32 code:
- Change hash iterators to take an iterator over `(Vec<u8>, Option<Vec<u8>>)` instead of file paths.
- Add a wrapper over needletail that provides this iterator.
- Add a `sketch_data` function that does not rely on file paths.
- Make `sketch_files` use sketch_data after reading the required data.
- Add a `SketchingOpts` struct that stores the parameters needed to sketch a (single) sample.
   * Defaults to values used in the CLI when possible.
   * SketchingOpts doesn't fill the sample name or k-mer sizes by default.
- Add a `from_sketches` constructor for MultiSketch that assigns indexes to each sketch and populates sketch_bins so that the constructed MultiSketch can be used with the other functions.

### Example usage for sketch_data

```
use sketchlib::sketch::{Sketch, SketchingOpts};
use sketchlib::sketch::sketch_data;

use std::collections::HashSet;
use std::path::PathBuf;

/// Iterator for needletail records
pub struct NeedletailFilterIterator {
    reader: Box<dyn needletail::FastxReader>,
    want_ids: HashSet<u32>,
    current_idx: u32,
}

impl NeedletailFilterIterator {
    /// Construct from needletail readers
    pub fn new(
        reader: Box<dyn needletail::FastxReader>,
        want_ids: HashSet<u32>,
    ) -> Self {
        Self {
            reader,
            want_ids,
            current_idx: 0_u32,
        }
    }
}

impl Iterator for NeedletailFilterIterator {
    type Item = (Vec<u8>, Option<Vec<u8>>);

    fn next(
        &mut self,
    ) -> Option<(Vec<u8>, Option<Vec<u8>>)> {
        while let Some(try_record) = self.reader.next() {
            if self.want_ids.contains(&self.current_idx) {
                let record = try_record.expect("Invalid fastX record");
                let seq = record.seq();
                let qual = record.qual().map(|qual| qual.to_vec());
                self.current_idx += 1;
                return Some((seq.to_vec(), qual))
            }
            self.current_idx += 1;
        }
        None
    }
}

/// Sketch a fastX file filtered by the index of reads to include in the sketch
pub fn sketch_reads_with_filter(
    fastx_path: &PathBuf,
    want_ids: HashSet<u32>,
    opts: SketchingOpts,
) -> Vec<Sketch> {
    let reader = needletail::parse_fastx_file(fastx_path).unwrap();
    let mut filtered_iters = vec![NeedletailFilterIterator::new(reader, want_ids)];

    sketch_data(&mut filtered_iters, opts)
}
```